### PR TITLE
clarify gt loader check

### DIFF
--- a/src/main/java/com/gtnewhorizon/randomboubles/RandomBoubles.java
+++ b/src/main/java/com/gtnewhorizon/randomboubles/RandomBoubles.java
@@ -38,7 +38,7 @@ public class RandomBoubles {
         }
         if (Loader.isModLoaded("gregtech")) {
             Constants.Gregtech = true;
-        }
+        } // Note that just testing for "gregtech" also includes other gt versions (gt6)
         if (Loader.isModLoaded("dreamcraft")) {
             Constants.GTNH = true;
         }


### PR DESCRIPTION
this loader check can stay as just "gregtech" because all it's used for is setting a ring to use plates instead of ingots (with other gt's also have), but some clarification is needed for the future